### PR TITLE
Add the ability to hide the `back` command option

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ module.exports = {
    - level?: number => Level of the current section (0 = main section)
    - headline?: string => Headline for the current section
    - showHelp?: boolean => If you want to show the `help` command at the top
+   - hideBack?: boolean => If you want to hide the `back` command at the bottom
    - setCache?: boolean => Re-use these `options` in subsequent menus (doesn't apply for `level`, `headline` or `setCache`)
    - backLabel?: string => custom label to indicate `go back` action
    - cancelLabel?: string => custom label to indicate `cancel` action

--- a/src/extensions/menu.extension.ts
+++ b/src/extensions/menu.extension.ts
@@ -21,6 +21,7 @@ export class Menu {
       level?: number;
       headline?: string;
       showHelp?: boolean;
+      hideBack?: boolean;
       setCache?: boolean;
       helpLabel?: string;
       backLabel?: string;
@@ -33,7 +34,7 @@ export class Menu {
       && (
         !!options.showHelp || !!options.helpLabel
         || !!options.backLabel || !!options.cancelLabel
-        || !!options.byeMessage
+        || !!options.byeMessage || !!options.hideBack
       )) {
       // save everything except level, headline & setCache
       this.optionsCache = { ...options };
@@ -98,7 +99,7 @@ export class Menu {
       mainCommands = [messages.help].concat(mainCommands)
     }
 
-    if (level) {
+    if (level && options.hideBack !== true) {
       mainCommands.push(messages.back);
     }
 


### PR DESCRIPTION
Hey 👋🏻

Found a use case where I need to disable the `back` menu option
when using `level` section > 0
and having a structure like this:
```
commands/
  - logged-in/
      ...commands
  - logged-out/
      ...commands
```

Would like to disable the `back` command since it doesn't do anything when the "first" level is 1